### PR TITLE
have the option to pass the cache behavior by path

### DIFF
--- a/bin/update-lambda-edge
+++ b/bin/update-lambda-edge
@@ -39,7 +39,7 @@ const getActiveTriggers = ({vreq, oreq, vres, ores}) => {
 const createConfig = args => {
   // removes undefined properties
   const definedArgs = JSON.parse(JSON.stringify(args))
-  const { config, pwd, filePath, distributionId, triggerName, functionName, lambdaVersion, autoIncrement, bucket, key, region, dryRun } = definedArgs
+  const { config, pwd, filePath, distributionId, triggerName, functionName, lambdaVersion, autoIncrement, bucket, key, region, dryRun, cacheBehaviorPath } = definedArgs
 
   let commandConfig
 
@@ -52,6 +52,7 @@ const createConfig = args => {
       dryRun: !!dryRun,
       cfDistributionID: distributionId || projectConfig.cfDistributionID,
       autoIncrementVersion: lambdaVersion ? false : projectConfig.autoIncrementVersion,
+      cacheBehavior: projectConfig.cacheBehaviorPath || 'default',
       lambdaCodeS3Bucket: bucket || projectConfig.lambdaCodeS3Bucket,
       awsRegion: region || projectConfig.awsRegion,
       cfTriggers: projectConfig.cfTriggers
@@ -68,6 +69,7 @@ const createConfig = args => {
       dryRun: !!dryRun,
       cfDistributionID: distributionId,
       autoIncrementVersion: lambdaVersion ? false : !!autoIncrement,
+      cacheBehavior: cacheBehaviorPath || 'default',
       lambdaCodeS3Bucket: bucket,
       awsRegion: region,
       cfTriggers: [
@@ -175,6 +177,10 @@ const cli = yargs(hideBin(process.argv))
       .option('lambda-version', {
         type: 'string',
         description: 'If true, will activate this version of the Lambda (overrides auto-increment)'
+      })
+      .option('cache-behavior-path', {
+        type: 'string',
+        description: 'If set, will activate this version of the Lambda to the corresponding cache behavior'
       })
   }, args => activateLambdas(createConfig(args)))
   .option('pwd', {


### PR DESCRIPTION
@benmarch  The following changes resolves https://github.com/benmarch/update-lambda-edge/issues/3 and allowed me to activate my lambdas on non-default cache behaviors, distinguished by the `Path Pattern` using the following config. Feel free to merge or modify according to your preference

```
{
  "awsRegion": "us-east-1",
  "autoIncrementVersion": true,
  "cfDistributionID": "1XY234ABC",
  "lambdaCodeS3Bucket": "my-s3-bucket",
  "cacheBehaviorPath": "/some-path"
  "cfTriggers": [ ... ]
}
```